### PR TITLE
Split Remaining Charge Time into Hours/Mins

### DIFF
--- a/polestar-medium-widget.js
+++ b/polestar-medium-widget.js
@@ -160,8 +160,10 @@ async function createPolestarWidget(batteryData, odometerData, vehicle) {
   if (isCharging) {
     const batteryChargingTimeStack = batteryInfoStack.addStack();
     batteryChargingTimeStack.addSpacer();
+    const remainingChargeTimeHours = parseInt(remainingChargingTime / 60);
+    const remainingChargeTimeMinsRemainder = remainingChargingTime % 60;
     const chargingTimeElement = batteryChargingTimeStack.addText(
-      `${remainingChargingTime} min`
+      `${remainingChargeTimeHours}h ${remainingChargeTimeMinsRemainder}m`
     );
     chargingTimeElement.font = Font.mediumSystemFont(14);
     chargingTimeElement.textColor = DARK_MODE ? Color.white() : Color.black();


### PR DESCRIPTION
I think this is a bit more understandable at quick glance.

![image](https://github.com/niklasvieth/polestar-ios-medium-widget/assets/44090970/1a76d193-3924-4ba4-9941-032eb450035e)


Loving the new updates to the widget. Hope we aren't locked out soon...