### PR TITLE
add vehicle name override

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Since the official Polestar App does not support any kind of widgets for iOS, I 
     const MIN_SOC_GREEN = 60;
     const MIN_SOC_ORANGE = 30;
     ```
+    
+    Using the setting below you can override the default vehicle name (Polestar 1/2/3) to a name of your choice, similar to the app functionality
+    ```js
+    let VEHICLE_NAME; // default name 
+    let VEHICLE_NAME = "Thor"; // change the name to "Thor"
+    ``` 
 
 5. Add the medium `Scriptable` widget to your homescreen. See [Apple How-To guide](https://support.apple.com/en-us/HT207122#:~:text=How%20to%20add%20widgets%20to%20your%20Home%20Screen).
 

--- a/polestar-medium-widget.js
+++ b/polestar-medium-widget.js
@@ -11,6 +11,8 @@ const POLESTAR_PASSWORD = "PASSWORD";
 // Optional (only necessary if more than one car linked to account)
 let VIN;
 // let VIN = "VIN";
+let VEHICLE_NAME;
+// let VEHICLE_NAME = "Thor";
 
 // Additional optional configuration
 const IMAGE_ANGLE = "0"; // Possible values 0,1,2,3,4,5
@@ -92,7 +94,7 @@ async function createPolestarWidget(batteryData, odometerData, vehicle) {
   }&width=600`;
 
   const appIcon = await loadImage(POLESTAR_ICON);
-  const title = vehicle.content.model.name;
+  const title = VEHICLE_NAME ?? vehicle.content.model.name;
   const widget = new ListWidget();
   widget.url = "polestar-explore://";
   const mainStack = widget.addStack();


### PR DESCRIPTION
@niklasvieth looking at the vehicle data API response, it doesn't seem to return the custom vehicle name users may have specified in the app so added functionality to override the model name and display what you want to instead.

![IMG_0976](https://github.com/niklasvieth/polestar-ios-medium-widget/assets/151760143/e72f5c20-2921-4db0-bbd5-37740e1f3625)
